### PR TITLE
Copy create args safely for discard

### DIFF
--- a/tests/integration/tests.cake
+++ b/tests/integration/tests.cake
@@ -46,7 +46,17 @@ Task("Discard-Release")
     settings.Milestone = data.GrmMilestone;
 
     // TODO: This can be replaced when a discard alias is added to Cake
-    settings.ArgumentCustomization = args => ProcessArgumentBuilder.FromString(args.Render().Replace("create", "discard"));
+    settings.ArgumentCustomization = args => {
+        var newArgs = new ProcessArgumentBuilder()
+                        .Append("discard");
+
+        Array.ForEach(
+            args.Skip(1).ToArray(),
+            newArgs.Append
+            );
+
+        return newArgs;
+    };
 
     GitReleaseManagerCreate(
         data.GitHubUsername,


### PR DESCRIPTION
Example
```csharp
{
    GitHubUsername = "test",
    GitHubPassword = "secret",
    GitHubOwner ="testorg",
    GitHubRepository ="repo",
    GrmMilestone = "v1"
}
```
Will now output 
```
discard -u "test" -p "[REDACTED]" -o "testorg" -r "repo" -m "v1"
```

